### PR TITLE
fix(ui): [hidden] must override modal/whoami display so modals actually hide

### DIFF
--- a/web/styles.css
+++ b/web/styles.css
@@ -18,6 +18,10 @@
 }
 
 * { box-sizing: border-box; }
+/* The [hidden] attribute must always win over class-level display rules
+   (.modal-backdrop/.whoami set display:flex, which would otherwise override
+   the UA [hidden]{display:none} and leave modals permanently visible). */
+[hidden] { display: none !important; }
 html, body { margin: 0; height: 100%; }
 body {
   font-family: "Segoe UI", system-ui, -apple-system, Roboto, Helvetica, Arial, sans-serif;


### PR DESCRIPTION
**Bug (reported with screenshots):** first screen is "messed up" and the walkthrough "Got it" button does nothing.

**Cause:** `.modal-backdrop` and `.whoami` set `display: flex`, which overrides the user-agent `[hidden] { display: none }` rule (author styles beat UA styles). So the auth modal + first-run walkthrough rendered on top of everything from page load, and toggling `element.hidden` in JS never actually hid them.

**Fix:** one global rule — `[hidden] { display: none !important; }` — so the attribute always wins.

**Verified in a real browser (Playwright + WebAuthn virtual authenticator):** no modals on load; Start shows the walkthrough; Next then "Got it" closes it and reveals the game; passkey register then logout then login all succeed; a played-out session saves to history (`/api/history`, `/api/summary`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
