### PR TITLE
security: harden auth, sessions, storage, and headers

### DIFF
--- a/api.go
+++ b/api.go
@@ -1,11 +1,12 @@
 package main
 
 import (
+	"encoding/json"
 	"net/http"
 )
 
 type saveReq struct {
-	Summary map[string]any `json:"summary"`
+	Summary gameSummary `json:"summary"`
 }
 
 func (a *App) handleSaveSession(w http.ResponseWriter, r *http.Request) {
@@ -14,9 +15,13 @@ func (a *App) handleSaveSession(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusUnauthorized, "sign in to save sessions")
 		return
 	}
+	// Decode into a strictly-typed numeric struct: unknown fields (e.g. the
+	// client's per-roll `results` array) are ignored and never stored, and any
+	// non-numeric value in a known field fails decoding — so no arbitrary or
+	// oversized JSON, and no markup, can reach the database or the history view.
 	var req saveReq
-	if err := readJSON(r, &req); err != nil || req.Summary == nil {
-		writeErr(w, http.StatusBadRequest, "summary is required")
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErr(w, http.StatusBadRequest, "invalid summary")
 		return
 	}
 	ctx, cancel := reqCtx(r)
@@ -41,15 +46,18 @@ func (a *App) handleHistory(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusInternalServerError, "could not load history")
 		return
 	}
-	// Flatten each session's summary + created_at for the client.
 	out := make([]map[string]any, 0, len(sessions))
 	for _, s := range sessions {
-		row := map[string]any{}
-		for k, v := range s.Summary {
-			row[k] = v
-		}
-		row["created_at"] = s.CreatedAt
-		out = append(out, row)
+		out = append(out, map[string]any{
+			"initial_bankroll": s.Summary.InitialBankroll,
+			"final_bankroll":   s.Summary.FinalBankroll,
+			"roll_count":       s.Summary.RollCount,
+			"points_hit":       s.Summary.PointsHit,
+			"strikes":          s.Summary.Strikes,
+			"total_wagered":    s.Summary.TotalWagered,
+			"net":              s.Summary.Net,
+			"created_at":       s.CreatedAt,
+		})
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"sessions": out})
 }
@@ -67,31 +75,14 @@ func (a *App) handleSummary(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusInternalServerError, "could not load summary")
 		return
 	}
-	var netTotal, rollsTotal float64
+	var netTotal, rollsTotal int64
 	for _, s := range sessions {
-		netTotal += toFloat(s.Summary["net"])
-		rollsTotal += toFloat(s.Summary["roll_count"])
+		netTotal += int64(s.Summary.Net)
+		rollsTotal += int64(s.Summary.RollCount)
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"count":       len(sessions),
-		"net_total":   int64(netTotal),
-		"rolls_total": int64(rollsTotal),
+		"net_total":   netTotal,
+		"rolls_total": rollsTotal,
 	})
-}
-
-func toFloat(v any) float64 {
-	switch n := v.(type) {
-	case float64:
-		return n
-	case float32:
-		return float64(n)
-	case int:
-		return float64(n)
-	case int32:
-		return float64(n)
-	case int64:
-		return float64(n)
-	default:
-		return 0
-	}
 }

--- a/app.go
+++ b/app.go
@@ -16,7 +16,8 @@ import (
 
 const sessionCookie = "craps_session"
 const ceremonyCookie = "craps_wa"
-const sessionTTL = 30 * 24 * time.Hour
+const sessionTTL = 7 * 24 * time.Hour
+const maxBodyBytes = 1 << 20 // 1 MiB request-body cap
 
 // App holds shared dependencies for the HTTP handlers.
 type App struct {

--- a/auth.go
+++ b/auth.go
@@ -1,19 +1,35 @@
 package main
 
 import (
+	"crypto/rand"
+	"encoding/base64"
 	"net/http"
 	"strings"
 )
 
+// validEmail is intentionally strict: exactly one '@', no surrounding '@', and
+// no whitespace, control characters, or '|' (the session-payload delimiter).
 func validEmail(e string) bool {
 	e = strings.TrimSpace(e)
-	return len(e) >= 3 && len(e) <= 254 && strings.Count(e, "@") == 1 &&
-		!strings.HasPrefix(e, "@") && !strings.HasSuffix(e, "@")
+	if len(e) < 3 || len(e) > 254 {
+		return false
+	}
+	if strings.Count(e, "@") != 1 || strings.HasPrefix(e, "@") || strings.HasSuffix(e, "@") {
+		return false
+	}
+	for _, r := range e {
+		if r <= ' ' || r == '|' || r == 0x7f {
+			return false
+		}
+	}
+	return true
 }
 
 type emailReq struct {
 	Email string `json:"email"`
 }
+
+func normEmail(s string) string { return strings.ToLower(strings.TrimSpace(s)) }
 
 func (a *App) handleMe(w http.ResponseWriter, r *http.Request) {
 	email := a.currentEmail(r)
@@ -30,21 +46,37 @@ func (a *App) handleRegisterBegin(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusBadRequest, "a valid email is required")
 		return
 	}
-	email := strings.ToLower(strings.TrimSpace(req.Email))
+	email := normEmail(req.Email)
 	ctx, cancel := reqCtx(r)
 	defer cancel()
 
-	user, err := a.store.GetOrCreateUser(ctx, email)
-	if err != nil {
+	// Do NOT create the user yet — only persist on a successful finish.
+	existing, err := a.store.GetUser(ctx, email)
+	var user *User
+	var handle []byte
+	switch {
+	case err == nil:
+		user = existing
+		handle = existing.handle
+	case err == errNotFound:
+		h, herr := newHandle()
+		if herr != nil {
+			writeErr(w, http.StatusInternalServerError, "could not start registration")
+			return
+		}
+		handle = h
+		user = &User{email: email, handle: handle}
+	default:
 		writeErr(w, http.StatusInternalServerError, "could not load account")
 		return
 	}
+
 	options, session, err := a.wa.BeginRegistration(user)
 	if err != nil {
 		writeErr(w, http.StatusInternalServerError, "could not start registration")
 		return
 	}
-	if err := a.store.SaveWASession(ctx, email, session); err != nil {
+	if err := a.store.SaveWASession(ctx, email, session, handle); err != nil {
 		writeErr(w, http.StatusInternalServerError, "could not persist ceremony")
 		return
 	}
@@ -61,19 +93,28 @@ func (a *App) handleRegisterFinish(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := reqCtx(r)
 	defer cancel()
 
-	user, err := a.store.GetOrCreateUser(ctx, email)
-	if err != nil {
-		writeErr(w, http.StatusInternalServerError, "could not load account")
-		return
-	}
-	session, err := a.store.TakeWASession(ctx, email)
+	session, handle, err := a.store.TakeWASession(ctx, email)
 	if err != nil {
 		writeErr(w, http.StatusBadRequest, "registration session expired — start over")
 		return
 	}
+	// Reconstruct the ceremony user (existing creds excluded during verify).
+	user, gerr := a.store.GetUser(ctx, email)
+	if gerr == errNotFound {
+		user = &User{email: email, handle: handle}
+	} else if gerr != nil {
+		writeErr(w, http.StatusInternalServerError, "could not load account")
+		return
+	}
+
 	cred, err := a.wa.FinishRegistration(user, *session, r)
 	if err != nil {
 		writeErr(w, http.StatusBadRequest, "passkey registration failed")
+		return
+	}
+	// Persist the user (idempotent) and the new credential.
+	if _, err := a.store.EnsureUser(ctx, email, handle); err != nil {
+		writeErr(w, http.StatusInternalServerError, "could not save account")
 		return
 	}
 	if err := a.store.AddCredential(ctx, email, cred); err != nil {
@@ -91,30 +132,58 @@ func (a *App) handleLoginBegin(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusBadRequest, "a valid email is required")
 		return
 	}
-	email := strings.ToLower(strings.TrimSpace(req.Email))
+	email := normEmail(req.Email)
 	ctx, cancel := reqCtx(r)
 	defer cancel()
 
 	user, err := a.store.GetUser(ctx, email)
-	if err == errNotFound || (user != nil && len(user.WebAuthnCredentials()) == 0) {
-		writeErr(w, http.StatusNotFound, "no passkey found for that email")
-		return
-	}
-	if err != nil {
+	if err != nil && err != errNotFound {
 		writeErr(w, http.StatusInternalServerError, "could not load account")
 		return
 	}
+	// Anti-enumeration: for an unknown email (or one with no passkeys) return a
+	// well-formed decoy challenge with the same 200 shape. The ceremony simply
+	// fails at finish (no stored session), so existence isn't revealed here.
+	if err == errNotFound || len(user.WebAuthnCredentials()) == 0 {
+		a.setCeremony(w, email)
+		writeJSON(w, http.StatusOK, a.decoyAssertion())
+		return
+	}
+
 	options, session, err := a.wa.BeginLogin(user)
 	if err != nil {
 		writeErr(w, http.StatusInternalServerError, "could not start login")
 		return
 	}
-	if err := a.store.SaveWASession(ctx, email, session); err != nil {
+	if err := a.store.SaveWASession(ctx, email, session, user.handle); err != nil {
 		writeErr(w, http.StatusInternalServerError, "could not persist ceremony")
 		return
 	}
 	a.setCeremony(w, email)
 	writeJSON(w, http.StatusOK, options)
+}
+
+// decoyAssertion returns a syntactically valid, useless assertion options object
+// (random challenge, no allowed credentials) so login/begin looks identical for
+// existing and non-existing accounts.
+func (a *App) decoyAssertion() map[string]any {
+	c := make([]byte, 32)
+	_, _ = rand.Read(c)
+	fakeID := make([]byte, 32)
+	_, _ = rand.Read(fakeID)
+	// Include one plausible (random) credential so the response shape matches a
+	// real single-passkey account — an empty allowCredentials would itself reveal
+	// that the email is unknown.
+	return map[string]any{"publicKey": map[string]any{
+		"challenge": base64.RawURLEncoding.EncodeToString(c),
+		"timeout":   60000,
+		"rpId":      a.cfg.RPID,
+		"allowCredentials": []any{map[string]any{
+			"type": "public-key",
+			"id":   base64.RawURLEncoding.EncodeToString(fakeID),
+		}},
+		"userVerification": "preferred",
+	}}
 }
 
 func (a *App) handleLoginFinish(w http.ResponseWriter, r *http.Request) {
@@ -131,7 +200,7 @@ func (a *App) handleLoginFinish(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusBadRequest, "no such account")
 		return
 	}
-	session, err := a.store.TakeWASession(ctx, email)
+	session, _, err := a.store.TakeWASession(ctx, email)
 	if err != nil {
 		writeErr(w, http.StatusBadRequest, "login session expired — start over")
 		return

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -26,14 +27,10 @@ type Config struct {
 
 func loadConfig() Config {
 	port := getenv("PORT", "8080")
-	secret := os.Getenv("SECRET_KEY")
-	if secret == "" {
-		secret = "dev-only-not-secret-change-me"
-	}
 	return Config{
 		Port:          port,
 		MongoURI:      os.Getenv("MONGO_URI"),
-		SessionSecret: []byte(secret),
+		SessionSecret: []byte(os.Getenv("SECRET_KEY")),
 		RPID:          getenv("RP_ID", "localhost"),
 		RPOrigin:      getenv("RP_ORIGIN", "http://localhost:"+port),
 		DBName:        getenv("MONGO_DB", "craps_game"),
@@ -52,6 +49,15 @@ func main() {
 	if cfg.MongoURI == "" {
 		log.Fatal("MONGO_URI is not set")
 	}
+	// Fail closed: a real (https) deployment must set SECRET_KEY, otherwise
+	// session cookies would be signed with a publicly-known key and forgeable.
+	if len(cfg.SessionSecret) == 0 {
+		if strings.HasPrefix(cfg.RPOrigin, "https://") {
+			log.Fatal("SECRET_KEY is required in production (RP_ORIGIN is https)")
+		}
+		log.Println("WARNING: SECRET_KEY unset — using an insecure dev key (localhost only)")
+		cfg.SessionSecret = []byte("dev-only-not-secret-change-me")
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
@@ -69,9 +75,13 @@ func main() {
 	mux := http.NewServeMux()
 	app.routes(mux)
 
+	// 60 auth/api requests per minute per client IP.
+	rl := newRateLimiter(60, time.Minute)
+	handler := logRequests(securityHeaders(rateLimit(rl, limitBody(mux))))
+
 	srv := &http.Server{
 		Addr:              ":" + cfg.Port,
-		Handler:           logRequests(mux),
+		Handler:           handler,
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 	log.Printf("listening on :%s (rp_id=%s origin=%s)", cfg.Port, cfg.RPID, cfg.RPOrigin)

--- a/middleware.go
+++ b/middleware.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// securityHeaders sets defensive response headers on every request. The CSP is
+// strict: only same-origin scripts/styles/assets, no inline script, no framing.
+func securityHeaders(next http.Handler) http.Handler {
+	const csp = "default-src 'self'; script-src 'self'; style-src 'self'; " +
+		"img-src 'self' data:; connect-src 'self'; font-src 'self'; object-src 'none'; " +
+		"base-uri 'none'; form-action 'self'; frame-ancestors 'none'"
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h := w.Header()
+		h.Set("Content-Security-Policy", csp)
+		h.Set("X-Content-Type-Options", "nosniff")
+		h.Set("X-Frame-Options", "DENY")
+		h.Set("Referrer-Policy", "no-referrer")
+		h.Set("Cross-Origin-Opener-Policy", "same-origin")
+		next.ServeHTTP(w, r)
+	})
+}
+
+// limitBody caps request bodies to guard against memory-exhaustion.
+func limitBody(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Body != nil {
+			r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// ---- per-IP fixed-window rate limiting ------------------------------------
+
+type rateLimiter struct {
+	mu     sync.Mutex
+	hits   map[string]*rlWindow
+	limit  int
+	window time.Duration
+}
+
+type rlWindow struct {
+	count int
+	reset time.Time
+}
+
+func newRateLimiter(limit int, window time.Duration) *rateLimiter {
+	return &rateLimiter{hits: make(map[string]*rlWindow), limit: limit, window: window}
+}
+
+func (rl *rateLimiter) allow(ip string, now time.Time) bool {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	w := rl.hits[ip]
+	if w == nil || now.After(w.reset) {
+		if len(rl.hits) > 10000 { // opportunistic cleanup of expired entries
+			for k, v := range rl.hits {
+				if now.After(v.reset) {
+					delete(rl.hits, k)
+				}
+			}
+		}
+		rl.hits[ip] = &rlWindow{count: 1, reset: now.Add(rl.window)}
+		return true
+	}
+	if w.count >= rl.limit {
+		return false
+	}
+	w.count++
+	return true
+}
+
+// rateLimit throttles the auth + api surfaces per client IP.
+func rateLimit(rl *rateLimiter, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p := r.URL.Path
+		if strings.HasPrefix(p, "/auth/") || strings.HasPrefix(p, "/api/") {
+			if !rl.allow(clientIP(r), time.Now()) {
+				w.Header().Set("Retry-After", "60")
+				writeErr(w, http.StatusTooManyRequests, "too many requests — slow down")
+				return
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// clientIP returns the real caller IP. On Heroku the router appends the true
+// client IP as the LAST entry of X-Forwarded-For; earlier entries are
+// client-supplied and spoofable, so we deliberately take the last one. (DNS is
+// grey-cloud, so CF-Connecting-IP is untrusted and ignored.)
+func clientIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		parts := strings.Split(xff, ",")
+		return strings.TrimSpace(parts[len(parts)-1])
+	}
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		return host
+	}
+	return r.RemoteAddr
+}

--- a/server_test.go
+++ b/server_test.go
@@ -65,7 +65,8 @@ func TestCurrentEmailExpired(t *testing.T) {
 
 func TestValidEmail(t *testing.T) {
 	ok := []string{"a@b.co", "user.name+tag@example.com"}
-	bad := []string{"", "nope", "@x.com", "x@", "a@@b", "  "}
+	bad := []string{"", "nope", "@x.com", "x@", "a@@b", "  ",
+		"a b@x.com", "pipe|payload@x.com", "ctrl\x00@x.com", "tab\t@x.com"}
 	for _, e := range ok {
 		if !validEmail(e) {
 			t.Errorf("expected valid: %q", e)
@@ -104,11 +105,30 @@ func TestHealthz(t *testing.T) {
 	}
 }
 
-func TestToFloat(t *testing.T) {
-	cases := map[any]float64{float64(3): 3, int(4): 4, int32(5): 5, int64(6): 6, "x": 0, nil: 0}
-	for in, want := range cases {
-		if got := toFloat(in); got != want {
-			t.Errorf("toFloat(%v)=%v want %v", in, got, want)
+func TestRateLimiter(t *testing.T) {
+	rl := newRateLimiter(3, time.Minute)
+	base := time.Unix(1_700_000_000, 0)
+	for i := 0; i < 3; i++ {
+		if !rl.allow("1.2.3.4", base) {
+			t.Fatalf("request %d should be allowed", i)
 		}
+	}
+	if rl.allow("1.2.3.4", base) {
+		t.Fatal("4th request in window should be blocked")
+	}
+	if !rl.allow("5.6.7.8", base) {
+		t.Fatal("a different IP should have its own bucket")
+	}
+	if !rl.allow("1.2.3.4", base.Add(time.Minute+time.Second)) {
+		t.Fatal("request after the window resets should be allowed")
+	}
+}
+
+func TestClientIPUsesLastForwardedFor(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	// Heroku appends the real client IP last; spoofed entries come first.
+	r.Header.Set("X-Forwarded-For", "9.9.9.9, 203.0.113.7")
+	if ip := clientIP(r); ip != "203.0.113.7" {
+		t.Fatalf("clientIP = %q, want the last (Heroku-appended) entry", ip)
 	}
 }

--- a/store.go
+++ b/store.go
@@ -46,15 +46,26 @@ func NewStore(ctx context.Context, cfg Config) (*Store, error) {
 	_, _ = s.sessions.Indexes().CreateOne(ctx, mongo.IndexModel{
 		Keys: bson.D{{Key: "email", Value: 1}, {Key: "created_at", Value: -1}},
 	})
+	// Stale, unfinished ceremonies self-expire so anonymous begin calls can't
+	// accumulate documents indefinitely.
+	_, _ = s.waSess.Indexes().CreateOne(ctx, mongo.IndexModel{
+		Keys: bson.D{{Key: "created_at", Value: 1}}, Options: options.Index().SetExpireAfterSeconds(600),
+	})
 	return s, nil
+}
+
+func newHandle() ([]byte, error) {
+	h := make([]byte, 32)
+	_, err := rand.Read(h)
+	return h, err
 }
 
 // ---- User model ------------------------------------------------------------
 
 type userDoc struct {
-	Email      string    `bson:"email"`
-	Handle     []byte    `bson:"handle"` // WebAuthn user id
-	CreatedAt  time.Time `bson:"created_at"`
+	Email     string    `bson:"email"`
+	Handle    []byte    `bson:"handle"` // WebAuthn user id
+	CreatedAt time.Time `bson:"created_at"`
 }
 
 type credDoc struct {
@@ -64,7 +75,7 @@ type credDoc struct {
 
 // User implements webauthn.User.
 type User struct {
-	email string
+	email  string
 	handle []byte
 	creds  []webauthn.Credential
 }
@@ -75,19 +86,13 @@ func (u *User) WebAuthnDisplayName() string                { return u.email }
 func (u *User) WebAuthnCredentials() []webauthn.Credential { return u.creds }
 func (u *User) WebAuthnIcon() string                       { return "" }
 
-// GetOrCreateUser returns the user, creating a bare record (no creds) if new.
-func (s *Store) GetOrCreateUser(ctx context.Context, email string) (*User, error) {
+// GetUser returns an existing user or errNotFound. It never creates a record —
+// user documents are only persisted once a passkey registration finishes.
+func (s *Store) GetUser(ctx context.Context, email string) (*User, error) {
 	var doc userDoc
 	err := s.users.FindOne(ctx, bson.M{"email": email}).Decode(&doc)
 	if err == mongo.ErrNoDocuments {
-		handle := make([]byte, 32)
-		if _, err := rand.Read(handle); err != nil {
-			return nil, err
-		}
-		doc = userDoc{Email: email, Handle: handle, CreatedAt: time.Now().UTC()}
-		if _, err := s.users.InsertOne(ctx, doc); err != nil {
-			return nil, err
-		}
+		return nil, errNotFound
 	} else if err != nil {
 		return nil, err
 	}
@@ -98,13 +103,17 @@ func (s *Store) GetOrCreateUser(ctx context.Context, email string) (*User, error
 	return &User{email: email, handle: doc.Handle, creds: creds}, nil
 }
 
-// GetUser returns an existing user or errNotFound.
-func (s *Store) GetUser(ctx context.Context, email string) (*User, error) {
+// EnsureUser persists the user with the given handle if it does not yet exist,
+// and returns the (existing or new) user. Called only at registration finish.
+func (s *Store) EnsureUser(ctx context.Context, email string, handle []byte) (*User, error) {
 	var doc userDoc
-	err := s.users.FindOne(ctx, bson.M{"email": email}).Decode(&doc)
-	if err == mongo.ErrNoDocuments {
-		return nil, errNotFound
-	} else if err != nil {
+	err := s.users.FindOneAndUpdate(
+		ctx,
+		bson.M{"email": email},
+		bson.M{"$setOnInsert": userDoc{Email: email, Handle: handle, CreatedAt: time.Now().UTC()}},
+		options.FindOneAndUpdate().SetUpsert(true).SetReturnDocument(options.After),
+	).Decode(&doc)
+	if err != nil {
 		return nil, err
 	}
 	creds, err := s.credentialsFor(ctx, email)
@@ -150,38 +159,56 @@ func (s *Store) UpdateCredential(ctx context.Context, email string, c *webauthn.
 type waSessionDoc struct {
 	Email     string               `bson:"email"`
 	Data      webauthn.SessionData `bson:"data"`
+	Handle    []byte               `bson:"handle"` // user handle chosen at begin, reused at finish
 	CreatedAt time.Time            `bson:"created_at"`
 }
 
-func (s *Store) SaveWASession(ctx context.Context, email string, data *webauthn.SessionData) error {
+func (s *Store) SaveWASession(ctx context.Context, email string, data *webauthn.SessionData, handle []byte) error {
 	_, err := s.waSess.UpdateOne(ctx,
 		bson.M{"email": email},
-		bson.M{"$set": waSessionDoc{Email: email, Data: *data, CreatedAt: time.Now().UTC()}},
+		bson.M{"$set": waSessionDoc{Email: email, Data: *data, Handle: handle, CreatedAt: time.Now().UTC()}},
 		options.Update().SetUpsert(true),
 	)
 	return err
 }
 
-func (s *Store) TakeWASession(ctx context.Context, email string) (*webauthn.SessionData, error) {
+func (s *Store) TakeWASession(ctx context.Context, email string) (*webauthn.SessionData, []byte, error) {
 	var doc waSessionDoc
 	err := s.waSess.FindOneAndDelete(ctx, bson.M{"email": email}).Decode(&doc)
 	if err == mongo.ErrNoDocuments {
-		return nil, errNotFound
+		return nil, nil, errNotFound
 	} else if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return &doc.Data, nil
+	return &doc.Data, doc.Handle, nil
 }
 
 // ---- Game history ----------------------------------------------------------
 
-type gameSession struct {
-	Email     string         `bson:"email" json:"-"`
-	Summary   map[string]any `bson:"summary" json:"summary"`
-	CreatedAt time.Time      `bson:"created_at" json:"created_at"`
+// gameSummary is the whitelisted, strictly-typed shape we persist. Only numeric
+// fields are accepted, so a client cannot store arbitrary/oversized JSON or
+// smuggle markup into the history view.
+type gameSummary struct {
+	InitialBankroll   float64 `json:"initial_bankroll" bson:"initial_bankroll"`
+	FinalBankroll     float64 `json:"final_bankroll" bson:"final_bankroll"`
+	RollCount         int     `json:"roll_count" bson:"roll_count"`
+	PointsEstablished int     `json:"points_established" bson:"points_established"`
+	PointsHit         int     `json:"points_hit" bson:"points_hit"`
+	PointsLost        int     `json:"points_lost" bson:"points_lost"`
+	Wins              float64 `json:"wins" bson:"wins"`
+	Losses            float64 `json:"losses" bson:"losses"`
+	Strikes           int     `json:"strikes" bson:"strikes"`
+	TotalWagered      float64 `json:"total_wagered" bson:"total_wagered"`
+	Net               float64 `json:"net" bson:"net"`
 }
 
-func (s *Store) SaveGameSession(ctx context.Context, email string, summary map[string]any) error {
+type gameSession struct {
+	Email     string      `bson:"email" json:"-"`
+	Summary   gameSummary `bson:"summary" json:"summary"`
+	CreatedAt time.Time   `bson:"created_at" json:"created_at"`
+}
+
+func (s *Store) SaveGameSession(ctx context.Context, email string, summary gameSummary) error {
 	_, err := s.sessions.InsertOne(ctx, gameSession{
 		Email: email, Summary: summary, CreatedAt: time.Now().UTC(),
 	})

--- a/web/app.js
+++ b/web/app.js
@@ -225,22 +225,45 @@ function friendly(e) {
 async function signOut() { try { await api('/auth/logout', { method: 'POST' }); } catch {} await refreshAuth(); }
 
 // ---- History ---------------------------------------------------------------
+// el builds a DOM node with a text child — never interpolates untrusted data
+// into HTML, so server values can't become markup.
+function el(tag, cls, text) {
+  const n = document.createElement(tag);
+  if (cls) n.className = cls;
+  if (text != null) n.textContent = String(text);
+  return n;
+}
+const num = (v) => (Number.isFinite(+v) ? +v : 0);
+
 async function openHistory() {
   try {
     const { sessions } = await api('/api/history');
     const agg = await api('/api/summary');
-    $('historyAgg').innerHTML =
-      `<span>Sessions: <b>${agg.count}</b></span>` +
-      `<span>Net lifetime: <b class="${agg.net_total >= 0 ? 'pos' : 'neg'}">${(agg.net_total >= 0 ? '+' : '') + fmt(agg.net_total)}</b></span>` +
-      `<span>Rolls: <b>${agg.rolls_total}</b></span>`;
-    $('historyList').innerHTML = sessions.length
-      ? sessions.map((s) => {
-          const net = s.net ?? (s.final_bankroll - s.initial_bankroll);
-          const when = s.created_at ? new Date(s.created_at).toLocaleString() : '';
-          return `<div class="hrow"><div><b>${fmt(s.initial_bankroll)}</b> → ${fmt(s.final_bankroll)}<br><small>${s.roll_count} rolls · ${when}</small></div>` +
-                 `<div class="net ${net >= 0 ? 'pos' : 'neg'}">${(net >= 0 ? '+' : '') + fmt(net)}</div></div>`;
-        }).join('')
-      : '<p class="muted">No saved sessions yet. Finish a game while signed in.</p>';
+    const netTotal = num(agg.net_total);
+    const aggEl = $('historyAgg');
+    aggEl.replaceChildren();
+    const s1 = el('span'); s1.append('Sessions: ', el('b', null, num(agg.count)));
+    const s2 = el('span'); s2.append('Net lifetime: ',
+      el('b', netTotal >= 0 ? 'pos' : 'neg', (netTotal >= 0 ? '+' : '') + fmt(netTotal)));
+    const s3 = el('span'); s3.append('Rolls: ', el('b', null, num(agg.rolls_total)));
+    aggEl.append(s1, s2, s3);
+
+    const list = $('historyList');
+    list.replaceChildren();
+    if (!sessions.length) {
+      list.append(el('p', 'muted', 'No saved sessions yet. Finish a game while signed in.'));
+    } else {
+      for (const s of sessions) {
+        const net = num(s.net);
+        const when = s.created_at ? new Date(s.created_at).toLocaleString() : '';
+        const left = el('div');
+        left.append(el('b', null, fmt(num(s.initial_bankroll))), ' → ' + fmt(num(s.final_bankroll)),
+          el('br'), el('small', null, `${num(s.roll_count)} rolls · ${when}`));
+        const right = el('div', 'net ' + (net >= 0 ? 'pos' : 'neg'), (net >= 0 ? '+' : '') + fmt(net));
+        const row = el('div', 'hrow'); row.append(left, right);
+        list.append(row);
+      }
+    }
     show('historyPanel');
   } catch (e) { alert('Could not load history: ' + e.message); }
 }

--- a/web/index.html
+++ b/web/index.html
@@ -6,7 +6,6 @@
   <meta name="theme-color" content="#1a1033" />
   <title>Dark Side Craps · Long Don't Strategy</title>
   <meta name="description" content="A disciplined Don't-Pass / lay-odds craps strategy tracker. Play close to the house edge, for a long time." />
-  <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="stylesheet" href="/styles.css" />
 </head>
 <body>


### PR DESCRIPTION
Implements every fix from the security review, plus two issues found and fixed during the pentest.

## From the review
- **#1 Fail-closed SECRET_KEY** — refuses to boot when `RP_ORIGIN` is https and `SECRET_KEY` is unset (no forgeable default-key sessions).
- **#2 Body-size limit** — global 1 MiB `http.MaxBytesReader`.
- **#3 Rate limiting + ceremony hardening** — 60/min per-IP on `/auth` + `/api` (keyed off the Heroku-appended last `X-Forwarded-For`; CF-Connecting-IP ignored since DNS is grey-cloud); registration no longer creates a user doc until finish; `wa_sessions` gets a 10-min TTL index.
- **#4 Typed summary** — `map[string]any` → strict numeric struct; history/summary read typed fields only.
- **#5/#9 CSP + safe DOM + input hardening** — strict CSP (no inline script) + nosniff/XFO/Referrer-Policy/COOP; history rendered via `textContent`/DOM builders; email validation rejects whitespace/control chars/`|`; session TTL 30d → 7d.
- **#6 Enumeration** — unknown emails get an identical 200 decoy assertion.

## Found + fixed during the pentest
- **Enumeration leak in the decoy** — first version returned `allowCredentials: []` while real users return a populated array, so existence still leaked. Fixed: decoy now includes one random fake credential; parity re-verified (known vs unknown both 200, `allowCredentials` length 1).
- **`DisallowUnknownFields` would break real saves** — the real client posts a `results[]` array not in the struct; strict rejection would 400 every save. Removed it; the typed struct still rejects wrong types. Re-verified: full client shape → 200 (results ignored, not stored), string-in-numeric → 400.

## Verification (local, WebAuthn virtual authenticator)
Security headers present; no CORS; 2 MiB body → 400; `/api/history` no cookie → 401; forged/wrong-secret cookies → unauthenticated; bad emails → 400; rate-limit → 429 after 60, other IPs unaffected; `register/begin` creates 0 user docs; strict summary decode; register → logout → login and history persistence all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
