### PR TITLE
chore: HSTS header + CI actions on Node 24

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,16 +24,16 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.23'
           cache: true
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
 
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/middleware.go
+++ b/middleware.go
@@ -21,6 +21,12 @@ func securityHeaders(next http.Handler) http.Handler {
 		h.Set("X-Frame-Options", "DENY")
 		h.Set("Referrer-Policy", "no-referrer")
 		h.Set("Cross-Origin-Opener-Policy", "same-origin")
+		// HSTS only over HTTPS (TLS terminates at the Heroku router, so the
+		// scheme is in X-Forwarded-Proto). No includeSubDomains — this host must
+		// not force HSTS on sibling *.moosequest.app subdomains.
+		if r.Header.Get("X-Forwarded-Proto") == "https" {
+			h.Set("Strict-Transport-Security", "max-age=31536000")
+		}
 		next.ServeHTTP(w, r)
 	})
 }


### PR DESCRIPTION
- **HSTS**: send `Strict-Transport-Security: max-age=31536000` on https requests (gated on `X-Forwarded-Proto`; no `includeSubDomains` so sibling *.moosequest.app hosts are unaffected).
- **CI**: bump `actions/checkout` v4→v7, `setup-go` v5→v6, `setup-node` v4→v7 to clear the Node 20 deprecation warnings.

Verified locally: HSTS absent over http, present with `X-Forwarded-Proto: https`; go vet/build/test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)