### PR TITLE
feat(auth): email-verified passkey signup

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ cd web && node --test    # craps engine: every transition, strikes, seven-out
 | `RP_ORIGIN` | Full origin (`https://craps.moosequest.app`) |
 | `MONGO_DB` | Database name (default `craps_game`) |
 | `PORT` | Listen port (default `8080`; set by Heroku) |
+| `SMTP_HOST` | Transactional-email relay host. **When set, signup email-verification is enforced** (an emailed 6-digit code is required before a passkey can be created). Unset ⇒ open registration (dev). |
+| `SMTP_PORT` | SMTP submission port (default `587`) |
+| `SMTP_USERNAME` / `SMTP_PASSWORD` | SMTP auth (optional; PLAIN over STARTTLS) |
+| `MAIL_FROM` | From address (default `Dark Side Craps <no-reply@moosequest.app>`) |
 
 Secrets are sourced from the **mqcraps** project in the vault (vault.raxx.app); see
 `.vault.toml`. On Heroku they are injected as config vars.

--- a/app.go
+++ b/app.go
@@ -52,6 +52,7 @@ func (a *App) routes(mux *http.ServeMux) {
 
 	// Auth.
 	mux.HandleFunc("/auth/me", a.handleMe)
+	mux.HandleFunc("/auth/register/send-code", a.postOnly(a.handleRegisterSendCode))
 	mux.HandleFunc("/auth/register/begin", a.postOnly(a.handleRegisterBegin))
 	mux.HandleFunc("/auth/register/finish", a.postOnly(a.handleRegisterFinish))
 	mux.HandleFunc("/auth/login/begin", a.postOnly(a.handleLoginBegin))

--- a/auth.go
+++ b/auth.go
@@ -1,11 +1,36 @@
 package main
 
 import (
+	"crypto/hmac"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"math/big"
 	"net/http"
 	"strings"
+	"time"
 )
+
+const verifyCodeTTL = 10 * time.Minute
+
+// genCode returns a cryptographically-random 6-digit code.
+func genCode() (string, error) {
+	n, err := rand.Int(rand.Reader, big.NewInt(1_000_000))
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%06d", n.Int64()), nil
+}
+
+// hashCode binds the code to the email under the server secret so plaintext
+// codes are never stored.
+func (a *App) hashCode(email, code string) string {
+	m := hmac.New(sha256.New, a.cfg.SessionSecret)
+	m.Write([]byte(email + "|" + strings.TrimSpace(code)))
+	return hex.EncodeToString(m.Sum(nil))
+}
 
 // validEmail is intentionally strict: exactly one '@', no surrounding '@', and
 // no whitespace, control characters, or '|' (the session-payload delimiter).
@@ -40,8 +65,46 @@ func (a *App) handleMe(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"authenticated": true, "email": email})
 }
 
-func (a *App) handleRegisterBegin(w http.ResponseWriter, r *http.Request) {
+// handleRegisterSendCode emails a one-time verification code for signup. When
+// email verification is disabled (no SMTP configured), it reports sent=false so
+// the client proceeds straight to the passkey step.
+func (a *App) handleRegisterSendCode(w http.ResponseWriter, r *http.Request) {
 	var req emailReq
+	if err := readJSON(r, &req); err != nil || !validEmail(req.Email) {
+		writeErr(w, http.StatusBadRequest, "a valid email is required")
+		return
+	}
+	if !a.cfg.verifyEmail() {
+		writeJSON(w, http.StatusOK, map[string]any{"sent": false})
+		return
+	}
+	email := normEmail(req.Email)
+	ctx, cancel := reqCtx(r)
+	defer cancel()
+
+	code, err := genCode()
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "could not generate code")
+		return
+	}
+	if err := a.store.SaveVerification(ctx, email, a.hashCode(email, code), verifyCodeTTL); err != nil {
+		writeErr(w, http.StatusInternalServerError, "could not start verification")
+		return
+	}
+	if err := a.sendVerificationEmail(email, code); err != nil {
+		writeErr(w, http.StatusInternalServerError, "could not send the verification email")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"sent": true})
+}
+
+type registerBeginReq struct {
+	Email string `json:"email"`
+	Code  string `json:"code"`
+}
+
+func (a *App) handleRegisterBegin(w http.ResponseWriter, r *http.Request) {
+	var req registerBeginReq
 	if err := readJSON(r, &req); err != nil || !validEmail(req.Email) {
 		writeErr(w, http.StatusBadRequest, "a valid email is required")
 		return
@@ -49,6 +112,20 @@ func (a *App) handleRegisterBegin(w http.ResponseWriter, r *http.Request) {
 	email := normEmail(req.Email)
 	ctx, cancel := reqCtx(r)
 	defer cancel()
+
+	// Require a valid, single-use emailed code before issuing a challenge, so a
+	// passkey can only be registered against an email the caller controls.
+	if a.cfg.verifyEmail() {
+		ok, err := a.store.ConsumeVerification(ctx, email, a.hashCode(email, req.Code))
+		if err != nil {
+			writeErr(w, http.StatusInternalServerError, "could not verify the code")
+			return
+		}
+		if !ok {
+			writeErr(w, http.StatusBadRequest, "invalid or expired verification code")
+			return
+		}
+	}
 
 	// Do NOT create the user yet — only persist on a successful finish.
 	existing, err := a.store.GetUser(ctx, email)

--- a/mailer.go
+++ b/mailer.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"fmt"
+	"net/smtp"
+	"strings"
+)
+
+// fromAddress extracts the bare "a@b.com" envelope address from a MailFrom that
+// may be in "Name <a@b.com>" form.
+func fromAddress(from string) string {
+	if i := strings.LastIndex(from, "<"); i >= 0 {
+		return strings.TrimSuffix(strings.TrimSpace(from[i+1:]), ">")
+	}
+	return strings.TrimSpace(from)
+}
+
+// sendVerificationEmail delivers a one-time code via SMTP. Uses STARTTLS when
+// the relay offers it (net/smtp.SendMail negotiates it automatically) and PLAIN
+// auth when credentials are configured. Works with any transactional relay
+// (Resend/SendGrid/SES/Mailgun/…) on a submission port (587).
+func (a *App) sendVerificationEmail(to, code string) error {
+	c := a.cfg
+	subject := "Your Dark Side Craps sign-in code"
+	body := fmt.Sprintf(
+		"Your verification code is %s\r\n\r\n"+
+			"Enter it to finish setting up your passkey. It expires in 10 minutes.\r\n"+
+			"If you didn't request this, you can ignore this email.\r\n",
+		code)
+	msg := "" +
+		"From: " + c.MailFrom + "\r\n" +
+		"To: " + to + "\r\n" +
+		"Subject: " + subject + "\r\n" +
+		"MIME-Version: 1.0\r\n" +
+		"Content-Type: text/plain; charset=UTF-8\r\n" +
+		"\r\n" + body
+
+	var auth smtp.Auth
+	if c.SMTPUser != "" {
+		auth = smtp.PlainAuth("", c.SMTPUser, c.SMTPPass, c.SMTPHost)
+	}
+	return smtp.SendMail(c.SMTPHost+":"+c.SMTPPort, auth, fromAddress(c.MailFrom), []string{to}, []byte(msg))
+}

--- a/main.go
+++ b/main.go
@@ -23,7 +23,18 @@ type Config struct {
 	RPID          string // WebAuthn Relying Party ID (the domain), e.g. craps.moosequest.app
 	RPOrigin      string // full origin, e.g. https://craps.moosequest.app
 	DBName        string
+
+	// SMTP for signup email-verification. When SMTPHost is empty, verification
+	// is disabled and registration proceeds without an emailed code (dev).
+	SMTPHost string
+	SMTPPort string
+	SMTPUser string
+	SMTPPass string
+	MailFrom string
 }
+
+// verifyEmail reports whether signup email-verification is enabled.
+func (c Config) verifyEmail() bool { return c.SMTPHost != "" }
 
 func loadConfig() Config {
 	port := getenv("PORT", "8080")
@@ -34,6 +45,11 @@ func loadConfig() Config {
 		RPID:          getenv("RP_ID", "localhost"),
 		RPOrigin:      getenv("RP_ORIGIN", "http://localhost:"+port),
 		DBName:        getenv("MONGO_DB", "craps_game"),
+		SMTPHost:      os.Getenv("SMTP_HOST"),
+		SMTPPort:      getenv("SMTP_PORT", "587"),
+		SMTPUser:      os.Getenv("SMTP_USERNAME"),
+		SMTPPass:      os.Getenv("SMTP_PASSWORD"),
+		MailFrom:      getenv("MAIL_FROM", "Dark Side Craps <no-reply@moosequest.app>"),
 	}
 }
 
@@ -84,7 +100,7 @@ func main() {
 		Handler:           handler,
 		ReadHeaderTimeout: 10 * time.Second,
 	}
-	log.Printf("listening on :%s (rp_id=%s origin=%s)", cfg.Port, cfg.RPID, cfg.RPOrigin)
+	log.Printf("listening on :%s (rp_id=%s origin=%s email_verification=%t)", cfg.Port, cfg.RPID, cfg.RPOrigin, cfg.verifyEmail())
 	if err := srv.ListenAndServe(); err != nil {
 		log.Fatal(err)
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -124,6 +124,62 @@ func TestRateLimiter(t *testing.T) {
 	}
 }
 
+func TestGenCode(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		c, err := genCode()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(c) != 6 {
+			t.Fatalf("code len %d: %q", len(c), c)
+		}
+		for _, r := range c {
+			if r < '0' || r > '9' {
+				t.Fatalf("non-digit in %q", c)
+			}
+		}
+	}
+}
+
+func TestHashCodeBinding(t *testing.T) {
+	a := testApp()
+	h := a.hashCode("a@b.com", "123456")
+	if h != a.hashCode("a@b.com", "123456") {
+		t.Fatal("hash not deterministic")
+	}
+	if h == a.hashCode("a@b.com", "654321") {
+		t.Fatal("different code produced same hash")
+	}
+	if h == a.hashCode("x@y.com", "123456") {
+		t.Fatal("different email produced same hash")
+	}
+	if h != a.hashCode("a@b.com", "  123456 ") {
+		t.Fatal("surrounding whitespace should be trimmed")
+	}
+	other := &App{cfg: Config{SessionSecret: []byte("other")}}
+	if h == other.hashCode("a@b.com", "123456") {
+		t.Fatal("hash must depend on the server secret")
+	}
+}
+
+func TestFromAddress(t *testing.T) {
+	if got := fromAddress("Dark Side Craps <no-reply@moosequest.app>"); got != "no-reply@moosequest.app" {
+		t.Fatalf("bracketed form: %q", got)
+	}
+	if got := fromAddress("plain@x.com"); got != "plain@x.com" {
+		t.Fatalf("plain form: %q", got)
+	}
+}
+
+func TestVerifyEmailToggle(t *testing.T) {
+	if (Config{}).verifyEmail() {
+		t.Fatal("no SMTP host should disable verification")
+	}
+	if !(Config{SMTPHost: "smtp.example.com"}).verifyEmail() {
+		t.Fatal("SMTP host should enable verification")
+	}
+}
+
 func TestClientIPUsesLastForwardedFor(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/", nil)
 	// Heroku appends the real client IP last; spoofed entries come first.

--- a/store.go
+++ b/store.go
@@ -21,6 +21,7 @@ type Store struct {
 	creds    *mongo.Collection
 	waSess   *mongo.Collection // in-flight WebAuthn ceremony data, keyed by email
 	sessions *mongo.Collection // saved game summaries
+	verifs   *mongo.Collection // pending email-verification codes, keyed by email
 }
 
 func NewStore(ctx context.Context, cfg Config) (*Store, error) {
@@ -38,6 +39,7 @@ func NewStore(ctx context.Context, cfg Config) (*Store, error) {
 		creds:    db.Collection("credentials"),
 		waSess:   db.Collection("wa_sessions"),
 		sessions: db.Collection("game_sessions"),
+		verifs:   db.Collection("email_verifications"),
 	}
 	// Best-effort indexes.
 	_, _ = s.users.Indexes().CreateOne(ctx, mongo.IndexModel{
@@ -50,6 +52,10 @@ func NewStore(ctx context.Context, cfg Config) (*Store, error) {
 	// accumulate documents indefinitely.
 	_, _ = s.waSess.Indexes().CreateOne(ctx, mongo.IndexModel{
 		Keys: bson.D{{Key: "created_at", Value: 1}}, Options: options.Index().SetExpireAfterSeconds(600),
+	})
+	// Verification codes expire exactly at their expires_at time (TTL 0).
+	_, _ = s.verifs.Indexes().CreateOne(ctx, mongo.IndexModel{
+		Keys: bson.D{{Key: "expires_at", Value: 1}}, Options: options.Index().SetExpireAfterSeconds(0),
 	})
 	return s, nil
 }
@@ -181,6 +187,44 @@ func (s *Store) TakeWASession(ctx context.Context, email string) (*webauthn.Sess
 		return nil, nil, err
 	}
 	return &doc.Data, doc.Handle, nil
+}
+
+// ---- Email verification codes ---------------------------------------------
+
+type verifyDoc struct {
+	Email     string    `bson:"email"`
+	CodeHash  string    `bson:"code_hash"`
+	ExpiresAt time.Time `bson:"expires_at"`
+	CreatedAt time.Time `bson:"created_at"`
+}
+
+// SaveVerification stores (or replaces) the pending code hash for an email.
+func (s *Store) SaveVerification(ctx context.Context, email, codeHash string, ttl time.Duration) error {
+	now := time.Now().UTC()
+	_, err := s.verifs.UpdateOne(ctx,
+		bson.M{"email": email},
+		bson.M{"$set": verifyDoc{Email: email, CodeHash: codeHash, ExpiresAt: now.Add(ttl), CreatedAt: now}},
+		options.Update().SetUpsert(true),
+	)
+	return err
+}
+
+// ConsumeVerification atomically checks a code hash for an email and deletes it
+// (single-use). Returns true only for a matching, unexpired code.
+func (s *Store) ConsumeVerification(ctx context.Context, email, codeHash string) (bool, error) {
+	var doc verifyDoc
+	err := s.verifs.FindOneAndDelete(ctx, bson.M{
+		"email":      email,
+		"code_hash":  codeHash,
+		"expires_at": bson.M{"$gt": time.Now().UTC()},
+	}).Decode(&doc)
+	if err == mongo.ErrNoDocuments {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // ---- Game history ----------------------------------------------------------

--- a/web/app.js
+++ b/web/app.js
@@ -167,15 +167,45 @@ async function refreshAuth() {
   if (auth.authenticated) $('whoamiEmail').textContent = auth.email;
 }
 
-function openAuth() { $('authError').hidden = true; $('authModal').hidden = false; $('email').focus(); }
-function closeAuth() { $('authModal').hidden = true; }
+function openAuth() { resetAuthSteps(); $('authModal').hidden = false; $('email').focus(); }
+function closeAuth() { $('authModal').hidden = true; resetAuthSteps(); }
 function authErr(msg) { const e = $('authError'); e.textContent = msg; e.hidden = false; }
 
-async function registerPasskey() {
+// Reset the modal to its first step (email + register/login actions).
+function resetAuthSteps() {
+  $('authError').hidden = true;
+  $('authActions').hidden = false;
+  $('codeField').hidden = true;
+  $('codeActions').hidden = true;
+  $('email').readOnly = false;
+  $('code').value = '';
+}
+
+// Step 1 of registration: request a verification code. If the server has email
+// verification disabled it returns sent=false and we go straight to the passkey.
+async function startRegister() {
   const email = $('email').value.trim();
   if (!email) return authErr('Enter your email first.');
+  $('authError').hidden = true;
   try {
-    const opts = await api('/auth/register/begin', { method: 'POST', body: { email } });
+    const res = await api('/auth/register/send-code', { method: 'POST', body: { email } });
+    if (res.sent) {
+      $('authActions').hidden = true;
+      $('codeField').hidden = false;
+      $('codeActions').hidden = false;
+      $('codeHint').textContent = `We emailed a 6-digit code to ${email}. Enter it to finish.`;
+      $('email').readOnly = true;
+      $('code').focus();
+    } else {
+      await registerPasskey(email, '');
+    }
+  } catch (e) { authErr(friendly(e)); }
+}
+
+// Step 2: create the passkey, sending the code (empty when verification is off).
+async function registerPasskey(email, code) {
+  try {
+    const opts = await api('/auth/register/begin', { method: 'POST', body: { email, code } });
     const pk = opts.publicKey;
     pk.challenge = b64urlToBuf(pk.challenge);
     pk.user.id = b64urlToBuf(pk.user.id);
@@ -314,7 +344,9 @@ function wire() {
   $('startSignInLink').addEventListener('click', (e) => { e.preventDefault(); openAuth(); });
   $('saveSignInBtn').addEventListener('click', openAuth);
   $('authClose').addEventListener('click', closeAuth);
-  $('passkeyRegisterBtn').addEventListener('click', registerPasskey);
+  $('passkeyRegisterBtn').addEventListener('click', startRegister);
+  $('verifyCreateBtn').addEventListener('click', () => registerPasskey($('email').value.trim(), $('code').value.trim()));
+  $('codeBackBtn').addEventListener('click', resetAuthSteps);
   $('passkeyLoginBtn').addEventListener('click', loginPasskey);
   $('signOutBtn').addEventListener('click', signOut);
   $('historyBtn').addEventListener('click', openHistory);

--- a/web/index.html
+++ b/web/index.html
@@ -133,9 +133,18 @@
         <label for="email">Email</label>
         <input type="email" id="email" inputmode="email" autocomplete="username webauthn" placeholder="you@example.com" />
       </div>
-      <div class="btn-row">
+      <div class="field" id="codeField" hidden>
+        <label for="code">Verification code</label>
+        <input type="text" id="code" inputmode="numeric" autocomplete="one-time-code" maxlength="6" placeholder="6-digit code" />
+        <p class="lede small" id="codeHint"></p>
+      </div>
+      <div class="btn-row" id="authActions">
         <button class="btn primary" id="passkeyRegisterBtn">Create passkey</button>
         <button class="btn" id="passkeyLoginBtn">Use existing passkey</button>
+      </div>
+      <div class="btn-row" id="codeActions" hidden>
+        <button class="btn primary" id="verifyCreateBtn">Verify &amp; create passkey</button>
+        <button class="btn ghost" id="codeBackBtn">Start over</button>
       </div>
       <p class="auth-error" id="authError" hidden></p>
     </div>

--- a/web/styles.css
+++ b/web/styles.css
@@ -88,11 +88,12 @@ body {
 /* Fields */
 .field { margin: 14px 0; }
 .field label { display: block; font-size: 12px; text-transform: uppercase; letter-spacing: 1.5px; color: var(--muted); margin-bottom: 8px; }
-input[type=email] {
+input[type=email], input[type=text] {
   width: 100%; padding: 13px 14px; border-radius: 12px; font-size: 16px;
   background: rgba(13,6,32,0.7); border: 1px solid var(--line); color: var(--ink);
 }
-input[type=email]:focus { outline: none; border-color: var(--pink); box-shadow: var(--glow); }
+input[type=email]:focus, input[type=text]:focus { outline: none; border-color: var(--pink); box-shadow: var(--glow); }
+#code { letter-spacing: 4px; font-weight: 700; text-align: center; }
 
 .segmented { display: flex; gap: 10px; }
 .seg {


### PR DESCRIPTION
Closes the open-registration finding: a one-time **emailed 6-digit code** is required before a passkey can be created, so an account can only be made by someone who controls the email.

- **Config-gated**: enforced only when `SMTP_HOST` is set. Unset (dev/CI/**and prod until creds are added**) = registration stays open, so merging is a no-op until an SMTP relay is configured.
- `net/smtp` sender (works with any relay on 587); codes stored as `HMAC(email|code)` under `SECRET_KEY`, single-use, TTL-expiring.
- New `POST /auth/register/send-code`; `register/begin` consumes the code. Login unchanged.
- Two-step signup UI (email → code → passkey).

**Verified end-to-end** with MailHog + WebAuthn virtual authenticator: email sent + parsed, wrong code rejected (no account), correct code → passkey → signed in; logout + login still work. All tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)