### PR TITLE
fix(auth): stop duplicate passkey signups; add multi-device passkey flow

### DIFF
--- a/app.go
+++ b/app.go
@@ -58,6 +58,8 @@ func (a *App) routes(mux *http.ServeMux) {
 	mux.HandleFunc("/auth/login/begin", a.postOnly(a.handleLoginBegin))
 	mux.HandleFunc("/auth/login/finish", a.postOnly(a.handleLoginFinish))
 	mux.HandleFunc("/auth/logout", a.postOnly(a.handleLogout))
+	mux.HandleFunc("/auth/passkey/add/begin", a.postOnly(a.handleAddPasskeyBegin))
+	mux.HandleFunc("/auth/passkey/add/finish", a.postOnly(a.handleAddPasskeyFinish))
 
 	// Game history (auth required).
 	mux.HandleFunc("/api/sessions", a.postOnly(a.handleSaveSession))

--- a/auth.go
+++ b/auth.go
@@ -127,26 +127,25 @@ func (a *App) handleRegisterBegin(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Do NOT create the user yet — only persist on a successful finish.
-	existing, err := a.store.GetUser(ctx, email)
-	var user *User
-	var handle []byte
-	switch {
-	case err == nil:
-		user = existing
-		handle = existing.handle
-	case err == errNotFound:
-		h, herr := newHandle()
-		if herr != nil {
-			writeErr(w, http.StatusInternalServerError, "could not start registration")
-			return
-		}
-		handle = h
-		user = &User{email: email, handle: handle}
-	default:
+	// Signup is for NEW accounts only. If the email already has a passkey, refuse
+	// and steer to sign-in — adding another passkey is an authenticated action
+	// (/auth/passkey/add/*). This is reached only after a valid emailed code, so
+	// it doesn't leak account existence to an attacker.
+	_, err := a.store.GetUser(ctx, email)
+	if err == nil {
+		writeErr(w, http.StatusConflict, "This email already has a passkey — sign in instead.")
+		return
+	}
+	if err != errNotFound {
 		writeErr(w, http.StatusInternalServerError, "could not load account")
 		return
 	}
+	handle, herr := newHandle()
+	if herr != nil {
+		writeErr(w, http.StatusInternalServerError, "could not start registration")
+		return
+	}
+	user := &User{email: email, handle: handle}
 
 	options, session, err := a.wa.BeginRegistration(user)
 	if err != nil {
@@ -200,6 +199,66 @@ func (a *App) handleRegisterFinish(w http.ResponseWriter, r *http.Request) {
 	}
 	a.clearCookie(w, ceremonyCookie)
 	a.setSession(w, email)
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "email": email})
+}
+
+// handleAddPasskeyBegin starts adding an additional passkey to the currently
+// signed-in account (multi-device). No email code — the session proves identity,
+// and BeginRegistration excludes the credentials already on the account.
+func (a *App) handleAddPasskeyBegin(w http.ResponseWriter, r *http.Request) {
+	email := a.currentEmail(r)
+	if email == "" {
+		writeErr(w, http.StatusUnauthorized, "sign in first")
+		return
+	}
+	ctx, cancel := reqCtx(r)
+	defer cancel()
+	user, err := a.store.GetUser(ctx, email)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "could not load account")
+		return
+	}
+	options, session, err := a.wa.BeginRegistration(user)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "could not start")
+		return
+	}
+	if err := a.store.SaveWASession(ctx, email, session, user.handle); err != nil {
+		writeErr(w, http.StatusInternalServerError, "could not persist ceremony")
+		return
+	}
+	a.setCeremony(w, email)
+	writeJSON(w, http.StatusOK, options)
+}
+
+func (a *App) handleAddPasskeyFinish(w http.ResponseWriter, r *http.Request) {
+	email := a.currentEmail(r)
+	if email == "" {
+		writeErr(w, http.StatusUnauthorized, "sign in first")
+		return
+	}
+	ctx, cancel := reqCtx(r)
+	defer cancel()
+	session, _, err := a.store.TakeWASession(ctx, email)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, "session expired — start over")
+		return
+	}
+	user, err := a.store.GetUser(ctx, email)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "could not load account")
+		return
+	}
+	cred, err := a.wa.FinishRegistration(user, *session, r)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, "could not add passkey")
+		return
+	}
+	if err := a.store.AddCredential(ctx, email, cred); err != nil {
+		writeErr(w, http.StatusInternalServerError, "could not save passkey")
+		return
+	}
+	a.clearCookie(w, ceremonyCookie)
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "email": email})
 }
 

--- a/web/app.js
+++ b/web/app.js
@@ -220,7 +220,15 @@ async function registerPasskey(email, code) {
       clientExtensionResults: cred.getClientExtensionResults(),
     } });
     closeAuth(); await refreshAuth();
-  } catch (e) { authErr(friendly(e)); }
+  } catch (e) {
+    // Account already exists: drop back to the email step so "Sign in" is offered.
+    if (/already has a passkey/i.test(String(e && e.message || e))) {
+      resetAuthSteps();
+      authErr('You already have a passkey for this email — tap Sign in.');
+      return;
+    }
+    authErr(friendly(e));
+  }
 }
 
 async function loginPasskey() {
@@ -248,10 +256,36 @@ async function loginPasskey() {
 
 function friendly(e) {
   const m = String(e && e.message || e);
-  if (/NotAllowed/i.test(m)) return 'Passkey prompt was dismissed. Try again.';
-  if (/already/i.test(m)) return 'That email already has a passkey — use "Use existing passkey".';
-  if (/no credential|not found/i.test(m)) return 'No passkey found for that email. Create one first.';
+  if (/already has a passkey/i.test(m)) return 'You already have a passkey for this email — tap Sign in.';
+  if (/NotAllowed/i.test(m)) return 'No passkey was used. New here? Tap Create account.';
+  if (/no passkey found/i.test(m)) return 'No passkey found for that email. Tap Create account.';
   return m;
+}
+
+// Add another passkey to the signed-in account (multi-device). No email code —
+// the session proves identity; the browser blocks duplicates on the same device.
+async function addPasskey() {
+  try {
+    const opts = await api('/auth/passkey/add/begin', { method: 'POST' });
+    const pk = opts.publicKey;
+    pk.challenge = b64urlToBuf(pk.challenge);
+    pk.user.id = b64urlToBuf(pk.user.id);
+    (pk.excludeCredentials || []).forEach((c) => (c.id = b64urlToBuf(c.id)));
+    const cred = await navigator.credentials.create({ publicKey: pk });
+    await api('/auth/passkey/add/finish', { method: 'POST', body: {
+      id: cred.id, rawId: bufToB64url(cred.rawId), type: cred.type,
+      response: {
+        attestationObject: bufToB64url(cred.response.attestationObject),
+        clientDataJSON: bufToB64url(cred.response.clientDataJSON),
+      },
+      clientExtensionResults: cred.getClientExtensionResults(),
+    } });
+    alert('Passkey added to this account.');
+  } catch (e) {
+    const m = String(e && e.message || e);
+    if (/InvalidState|already registered|exclude/i.test(m)) { alert('This device already has a passkey for your account.'); return; }
+    alert('Could not add passkey: ' + friendly(e));
+  }
 }
 
 async function signOut() { try { await api('/auth/logout', { method: 'POST' }); } catch {} await refreshAuth(); }
@@ -349,6 +383,7 @@ function wire() {
   $('codeBackBtn').addEventListener('click', resetAuthSteps);
   $('passkeyLoginBtn').addEventListener('click', loginPasskey);
   $('signOutBtn').addEventListener('click', signOut);
+  $('addPasskeyBtn').addEventListener('click', addPasskey);
   $('historyBtn').addEventListener('click', openHistory);
   $('historyCloseBtn').addEventListener('click', () => show('startPanel'));
 

--- a/web/index.html
+++ b/web/index.html
@@ -21,6 +21,7 @@
       <button class="btn ghost" id="signInBtn" hidden>Sign in</button>
       <div class="whoami" id="whoami" hidden>
         <span class="dot"></span><span id="whoamiEmail"></span>
+        <button class="btn ghost tiny" id="addPasskeyBtn">+ Passkey</button>
         <button class="btn ghost tiny" id="historyBtn">History</button>
         <button class="btn ghost tiny" id="signOutBtn">Sign out</button>
       </div>
@@ -128,7 +129,7 @@
     <div class="modal card" role="dialog" aria-modal="true" aria-labelledby="authTitle">
       <button class="modal-x" id="authClose" aria-label="Close">✕</button>
       <h2 class="title" id="authTitle">Sign in with a passkey</h2>
-      <p class="lede small">Enter your email. We'll create or use a passkey on this device — no passwords.</p>
+      <p class="lede small">Enter your email to sign in — or create an account. No passwords.</p>
       <div class="field">
         <label for="email">Email</label>
         <input type="email" id="email" inputmode="email" autocomplete="username webauthn" placeholder="you@example.com" />
@@ -139,8 +140,8 @@
         <p class="lede small" id="codeHint"></p>
       </div>
       <div class="btn-row" id="authActions">
-        <button class="btn primary" id="passkeyRegisterBtn">Create passkey</button>
-        <button class="btn" id="passkeyLoginBtn">Use existing passkey</button>
+        <button class="btn primary" id="passkeyLoginBtn">Sign in</button>
+        <button class="btn ghost" id="passkeyRegisterBtn">Create account</button>
       </div>
       <div class="btn-row" id="codeActions" hidden>
         <button class="btn primary" id="verifyCreateBtn">Verify &amp; create passkey</button>


### PR DESCRIPTION
A returning user could re-run **Create passkey** and silently add a second passkey to an existing account. Rework:

- **register/begin refuses** when the email already has a passkey (409 → "sign in instead"). Only reachable after a valid emailed code, so no enumeration leak.
- **New `/auth/passkey/add/{begin,finish}`** — a *signed-in* user can add another passkey (multi-device); no code needed, and `excludeCredentials` blocks same-device dupes at the browser.
- **UI**: "Sign in" is now primary, "Create account" secondary; a duplicate attempt shows a friendly message + drops back to sign-in; signed-in users get a "+ Passkey" button.

Verified E2E (MailHog + virtual authenticators): signup → 1 credential; duplicate create-account **blocked** (stays 1, not 3); add-passkey from a 2nd device → 2 credentials; sign-in with existing passkey works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)