### PR TITLE
feat: delete-account + Privacy Policy & Terms of Use

### DIFF
--- a/app.go
+++ b/app.go
@@ -49,6 +49,8 @@ func (a *App) routes(mux *http.ServeMux) {
 	mux.HandleFunc("/app.js", a.serveAsset("web/app.js", "text/javascript; charset=utf-8"))
 	mux.HandleFunc("/engine.js", a.serveAsset("web/engine.js", "text/javascript; charset=utf-8"))
 	mux.HandleFunc("/styles.css", a.serveAsset("web/styles.css", "text/css; charset=utf-8"))
+	mux.HandleFunc("/privacy", a.serveAsset("web/privacy.html", "text/html; charset=utf-8"))
+	mux.HandleFunc("/terms", a.serveAsset("web/terms.html", "text/html; charset=utf-8"))
 
 	// Auth.
 	mux.HandleFunc("/auth/me", a.handleMe)
@@ -60,6 +62,7 @@ func (a *App) routes(mux *http.ServeMux) {
 	mux.HandleFunc("/auth/logout", a.postOnly(a.handleLogout))
 	mux.HandleFunc("/auth/passkey/add/begin", a.postOnly(a.handleAddPasskeyBegin))
 	mux.HandleFunc("/auth/passkey/add/finish", a.postOnly(a.handleAddPasskeyFinish))
+	mux.HandleFunc("/auth/account/delete", a.postOnly(a.handleDeleteAccount))
 
 	// Game history (auth required).
 	mux.HandleFunc("/api/sessions", a.postOnly(a.handleSaveSession))

--- a/auth.go
+++ b/auth.go
@@ -358,3 +358,22 @@ func (a *App) handleLogout(w http.ResponseWriter, r *http.Request) {
 	a.clearCookie(w, sessionCookie)
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
 }
+
+// handleDeleteAccount permanently deletes the signed-in user's account and all
+// associated data, then clears the session.
+func (a *App) handleDeleteAccount(w http.ResponseWriter, r *http.Request) {
+	email := a.currentEmail(r)
+	if email == "" {
+		writeErr(w, http.StatusUnauthorized, "sign in first")
+		return
+	}
+	ctx, cancel := reqCtx(r)
+	defer cancel()
+	if err := a.store.DeleteAccount(ctx, email); err != nil {
+		writeErr(w, http.StatusInternalServerError, "could not delete account")
+		return
+	}
+	a.clearCookie(w, sessionCookie)
+	a.clearCookie(w, ceremonyCookie)
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+}

--- a/docs/legal/privacy.md
+++ b/docs/legal/privacy.md
@@ -1,0 +1,113 @@
+# Privacy Policy
+
+**Effective date: July 16, 2026**
+
+_This is a plain-language privacy policy for a small, free hobby app. It is not legal advice._
+
+---
+
+## Who we are
+
+Dark Side Craps (available at https://craps.moosequest.app) is operated by **MooseQuest LLC**. We can be reached at **privacy@moosequest.app** for any privacy-related questions.
+
+---
+
+## What this app is
+
+Dark Side Craps is a free, entertainment-only web app for learning and tracking a disciplined craps strategy using simulated dice rolls. **No real money is involved.** No wagering, no deposits, no payouts, no prizes.
+
+---
+
+## What we collect and why
+
+We collect the minimum necessary to run an account-based app.
+
+| Data | Why we collect it |
+|---|---|
+| **Email address** | Used as your account identifier and to send a one-time verification code at sign-in. |
+| **Passkey (WebAuthn public-key credential)** | Lets you sign in without a password. We store only the public-key portion — your private key never leaves your device. No passwords are ever collected or stored. |
+| **Game history** | Per-session summaries of your simulated play (starting bankroll, roll count, wins/losses, net result). All figures are pretend money. Stored so you can review your practice history. |
+| **Session cookie** | A signed, HttpOnly cookie that keeps you signed in during and across sessions. |
+| **Verification cookie** | A short-lived cookie issued during the sign-up/sign-in flow, discarded once verified. |
+
+We do **not** collect payment information, location data, advertising identifiers, or any sensitive personal data.
+
+---
+
+## Cookies
+
+We use exactly two types of cookies:
+
+- **Session cookie** — keeps you authenticated. Signed and HttpOnly (not accessible to JavaScript). Expires when you sign out or after a reasonable inactivity period.
+- **Verification cookie** — short-lived; used only during the email-verification step at sign-up or sign-in.
+
+We do **not** use advertising cookies, tracking pixels, analytics cookies, or any third-party cookies.
+
+---
+
+## How your data is stored and secured
+
+- All data is transmitted over HTTPS (TLS-encrypted in transit).
+- Account data (email, passkey credentials, game history) is stored in **MongoDB** hosted by a managed MongoDB database host.
+- Passkey credentials are stored as public-key material only; no passwords exist in our system.
+- Session cookies are signed and HttpOnly to resist tampering and cross-site script access.
+
+We are a small hobby operation and implement reasonable security measures, but we cannot guarantee absolute security.
+
+---
+
+## Third-party processors
+
+We share data only with the vendors needed to operate the service. We do **not** sell your data.
+
+| Vendor | Role | Data involved |
+|---|---|---|
+| **Postmark** | Transactional email (verification codes) | Your email address |
+| **Heroku** | Application hosting | All app data in transit and at rest on Heroku infrastructure |
+| **Cloudflare** | DNS and edge/CDN layer | IP addresses and request metadata (standard CDN handling) |
+| **MongoDB host** | Database storage | Email, passkey credentials, game history |
+
+Each vendor has its own privacy practices. We encourage you to review them if you have concerns.
+
+---
+
+## Data retention and deletion
+
+- We retain your account data for as long as your account is active.
+- **You can delete your account at any time** using the "Delete account" button inside the app. This permanently and immediately removes your email address, passkey credentials, and all game history. Deletion is irreversible.
+- We may retain anonymized, non-identifiable aggregate statistics (e.g., "N sessions were played this month") that cannot be linked back to you.
+- If we receive a verifiable deletion request by email, we will process it within 30 days.
+
+---
+
+## Children
+
+This app is not directed to children under **13**. We do not knowingly collect personal data from anyone below that age. If you believe a child has created an account, contact us at privacy@moosequest.app and we will delete it promptly.
+
+---
+
+## Your rights
+
+Regardless of where you live, you can:
+
+- **Access** your data — contact us and we will tell you what we hold about you.
+- **Delete** your data — use the in-app "Delete account" button (instant) or contact privacy@moosequest.app.
+- **Correct** your data — contact us if your email address needs to change.
+
+**If you are in the European Union / European Economic Area / United Kingdom:** You may have additional rights under the GDPR (or UK GDPR), including the right to object to processing, the right to data portability, and the right to lodge a complaint with your local supervisory authority. Our legal basis for processing your data is the performance of the service you signed up for (Art. 6(1)(b) GDPR) and, where required, your consent.
+
+**If you are in California:** You may have rights under the CCPA/CPRA. We do not sell or share your personal information. We do not use it for cross-context behavioral advertising.
+
+---
+
+## Changes to this policy
+
+We may update this policy. If we make material changes, we will update the effective date at the top of this page. For a hobby app, we will make reasonable efforts to note significant changes; continued use after a change means you accept the updated policy.
+
+---
+
+## Contact
+
+Privacy questions or requests: **privacy@moosequest.app**
+
+---

--- a/docs/legal/terms.md
+++ b/docs/legal/terms.md
@@ -1,0 +1,119 @@
+# Terms of Use
+
+**Effective date: July 16, 2026**
+
+_This is a plain-language terms of use document for a small, free hobby app. It is not legal advice._
+
+---
+
+## 1. Who operates this app
+
+Dark Side Craps (https://craps.moosequest.app) is operated by **MooseQuest LLC** ("we," "us," or "our"). By using this app you agree to these terms.
+
+---
+
+## 2. What this app is — and what it is not
+
+**Dark Side Craps is a free, educational and entertainment-only strategy tracker.** It generates simulated dice rolls and gives guidance on a "Don't Pass / lay-odds" craps strategy with a running scoreboard.
+
+**This is NOT gambling.** There is no real money involved — no wagering, no deposits, no payouts, no prizes, no financial transactions of any kind. All bankroll figures, wins, and losses displayed are entirely fictional.
+
+**Nothing in this app is betting advice, financial advice, or gambling advice.** The strategy described is one disciplined approach to a game of chance; it is not a guaranteed system and we make no claim that it will produce any particular result.
+
+---
+
+## 3. Eligibility
+
+You must be at least **18 years old** (or the age of majority in your jurisdiction, if higher) to create an account and use this app. By using the app you represent that you meet this requirement.
+
+This app is not directed to anyone under the age of 13 and we do not knowingly collect data from minors. See our Privacy Policy for details.
+
+---
+
+## 4. Not for use in connection with real gambling
+
+> **Do not use this app at a casino, during real craps play, or to make real-money betting decisions.**
+
+This app exists for fun, self-education, and entertainment at home or wherever you enjoy strategy games. Simulated results under ideal conditions bear no necessary relationship to real-world craps outcomes. Real craps carries a house edge that no strategy can eliminate.
+
+---
+
+## 5. No warranties — "as is" and "as available"
+
+THE APP IS PROVIDED **"AS IS" AND "AS AVAILABLE"** WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED. WE MAKE NO REPRESENTATIONS OR WARRANTIES REGARDING:
+
+- Uptime, availability, or uninterrupted access;
+- Accuracy of dice simulation, strategy guidance, or scoreboard calculations;
+- Fitness for any particular purpose;
+- Freedom from bugs, errors, or security vulnerabilities.
+
+We are a small hobby operation running a free app. We will try to keep it working, but we make no promises.
+
+---
+
+## 6. Limitation of liability
+
+TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, **MooseQuest LLC** AND ITS MEMBERS, OFFICERS, AND AGENTS SHALL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR EXEMPLARY DAMAGES ARISING FROM YOUR USE OF (OR INABILITY TO USE) THIS APP, INCLUDING BUT NOT LIMITED TO:
+
+- Any real-money gambling losses you incur, regardless of whether you used this app;
+- Loss of data;
+- Inaccuracies in strategy guidance or simulation results;
+- Any reliance on this app for real-world decisions.
+
+Some jurisdictions do not allow certain liability exclusions; in those jurisdictions our liability is limited to the maximum extent permitted.
+
+---
+
+## 7. Acceptable use
+
+You agree not to:
+
+- Use the app for any unlawful purpose or in violation of any applicable law or regulation;
+- Attempt to reverse-engineer, decompile, exploit, or attack the app, its infrastructure, or its data;
+- Attempt to gain unauthorized access to other users' accounts or data;
+- Use automated scraping, bots, or scripts against the service in a way that harms its operation;
+- Impersonate another person or entity;
+- Use the app in connection with real-money gambling or wagering.
+
+---
+
+## 8. Accounts and termination
+
+You are responsible for maintaining the security of your account. We reserve the right to suspend or terminate any account at our discretion, including for violation of these terms or abuse of the service, without notice.
+
+You may delete your account at any time using the "Delete account" button in the app. Deletion is permanent and removes your email, passkey credentials, and game history.
+
+---
+
+## 9. Intellectual property
+
+All content, design, code, and strategy guidance in this app is owned by **MooseQuest LLC** or its licensors. You may not reproduce, distribute, or create derivative works without our written permission.
+
+---
+
+## 10. Third-party services
+
+The app relies on third-party infrastructure (hosting, email delivery, database, CDN). We are not responsible for the acts or omissions of those providers.
+
+---
+
+## 11. Changes to these terms
+
+We may update these terms at any time. Changes take effect when we post the updated version with a new effective date. Continued use of the app after changes are posted constitutes acceptance of the updated terms. For significant changes we will make reasonable efforts to alert users.
+
+---
+
+## 12. Governing law and disputes
+
+These terms are governed by the laws of **the state in which MooseQuest LLC is organized**, without regard to its conflict-of-law provisions.
+
+Any dispute arising from these terms or your use of the app shall be resolved in the state and federal courts located in that state. You waive any objection to jurisdiction or venue in those courts.
+
+
+---
+
+## 13. Contact
+
+Questions about these terms: **privacy@moosequest.app**
+
+---

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 	"time"
 )
 
-//go:embed web/index.html web/app.js web/engine.js web/styles.css
+//go:embed web/index.html web/app.js web/engine.js web/styles.css web/privacy.html web/terms.html
 var webFS embed.FS
 
 // Config is resolved from the environment (Heroku config vars / rvault).

--- a/store.go
+++ b/store.go
@@ -151,6 +151,18 @@ func (s *Store) AddCredential(ctx context.Context, email string, c *webauthn.Cre
 	return err
 }
 
+// DeleteAccount permanently removes the user and everything tied to their email:
+// credentials, saved games, in-flight ceremonies, and verification codes.
+func (s *Store) DeleteAccount(ctx context.Context, email string) error {
+	for _, c := range []*mongo.Collection{s.creds, s.sessions, s.waSess, s.verifs} {
+		if _, err := c.DeleteMany(ctx, bson.M{"email": email}); err != nil {
+			return err
+		}
+	}
+	_, err := s.users.DeleteOne(ctx, bson.M{"email": email})
+	return err
+}
+
 // UpdateCredential bumps the stored sign counter after a successful login.
 func (s *Store) UpdateCredential(ctx context.Context, email string, c *webauthn.Credential) error {
 	_, err := s.creds.UpdateOne(ctx,

--- a/web/app.js
+++ b/web/app.js
@@ -290,6 +290,16 @@ async function addPasskey() {
 
 async function signOut() { try { await api('/auth/logout', { method: 'POST' }); } catch {} await refreshAuth(); }
 
+async function deleteAccount() {
+  if (!confirm('Delete your account? This permanently removes your email, passkeys, and saved game history, and cannot be undone.')) return;
+  try {
+    await api('/auth/account/delete', { method: 'POST' });
+    await refreshAuth();
+    show('startPanel');
+    alert('Your account and all its data have been deleted.');
+  } catch (e) { alert('Could not delete account: ' + (e && e.message || e)); }
+}
+
 // ---- History ---------------------------------------------------------------
 // el builds a DOM node with a text child — never interpolates untrusted data
 // into HTML, so server values can't become markup.
@@ -384,6 +394,7 @@ function wire() {
   $('passkeyLoginBtn').addEventListener('click', loginPasskey);
   $('signOutBtn').addEventListener('click', signOut);
   $('addPasskeyBtn').addEventListener('click', addPasskey);
+  $('deleteAccountBtn').addEventListener('click', deleteAccount);
   $('historyBtn').addEventListener('click', openHistory);
   $('historyCloseBtn').addEventListener('click', () => show('startPanel'));
 

--- a/web/index.html
+++ b/web/index.html
@@ -24,6 +24,7 @@
         <button class="btn ghost tiny" id="addPasskeyBtn">+ Passkey</button>
         <button class="btn ghost tiny" id="historyBtn">History</button>
         <button class="btn ghost tiny" id="signOutBtn">Sign out</button>
+        <button class="btn ghost tiny danger" id="deleteAccountBtn">Delete account</button>
       </div>
     </div>
   </header>
@@ -124,6 +125,10 @@
     </section>
   </main>
 
+  <footer class="site-foot">
+    For fun only — not gambling. <a href="/terms">Terms of Use</a> · <a href="/privacy">Privacy Policy</a>
+  </footer>
+
   <!-- AUTH MODAL -->
   <div class="modal-backdrop" id="authModal" hidden>
     <div class="modal card" role="dialog" aria-modal="true" aria-labelledby="authTitle">
@@ -147,6 +152,7 @@
         <button class="btn primary" id="verifyCreateBtn">Verify &amp; create passkey</button>
         <button class="btn ghost" id="codeBackBtn">Start over</button>
       </div>
+      <p class="lede small">By continuing you agree to our <a href="/terms">Terms</a> &amp; <a href="/privacy">Privacy Policy</a>.</p>
       <p class="auth-error" id="authError" hidden></p>
     </div>
   </div>

--- a/web/privacy.html
+++ b/web/privacy.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Privacy Policy · Dark Side Craps</title>
+<meta name="robots" content="all" />
+<link rel="stylesheet" href="/styles.css" />
+</head>
+<body>
+<div class="grid-bg" aria-hidden="true"></div>
+<main class="legal">
+<a class="legal-back" href="/">← Dark Side Craps</a>
+<article class="legal-doc">
+<h1>Privacy Policy</h1>
+<p><strong>Effective date: July 16, 2026</strong></p>
+<p><em>This is a plain-language privacy policy for a small, free hobby app. It is not legal advice.</em></p>
+<hr />
+<h2>Who we are</h2>
+<p>Dark Side Craps (available at https://craps.moosequest.app) is operated by <strong>MooseQuest LLC</strong>. We can be reached at <strong>privacy@moosequest.app</strong> for any privacy-related questions.</p>
+<hr />
+<h2>What this app is</h2>
+<p>Dark Side Craps is a free, entertainment-only web app for learning and tracking a disciplined craps strategy using simulated dice rolls. <strong>No real money is involved.</strong> No wagering, no deposits, no payouts, no prizes.</p>
+<hr />
+<h2>What we collect and why</h2>
+<p>We collect the minimum necessary to run an account-based app.</p>
+<table>
+<thead>
+<tr>
+<th>Data</th>
+<th>Why we collect it</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Email address</strong></td>
+<td>Used as your account identifier and to send a one-time verification code at sign-in.</td>
+</tr>
+<tr>
+<td><strong>Passkey (WebAuthn public-key credential)</strong></td>
+<td>Lets you sign in without a password. We store only the public-key portion — your private key never leaves your device. No passwords are ever collected or stored.</td>
+</tr>
+<tr>
+<td><strong>Game history</strong></td>
+<td>Per-session summaries of your simulated play (starting bankroll, roll count, wins/losses, net result). All figures are pretend money. Stored so you can review your practice history.</td>
+</tr>
+<tr>
+<td><strong>Session cookie</strong></td>
+<td>A signed, HttpOnly cookie that keeps you signed in during and across sessions.</td>
+</tr>
+<tr>
+<td><strong>Verification cookie</strong></td>
+<td>A short-lived cookie issued during the sign-up/sign-in flow, discarded once verified.</td>
+</tr>
+</tbody>
+</table>
+<p>We do <strong>not</strong> collect payment information, location data, advertising identifiers, or any sensitive personal data.</p>
+<hr />
+<h2>Cookies</h2>
+<p>We use exactly two types of cookies:</p>
+<ul>
+<li><strong>Session cookie</strong> — keeps you authenticated. Signed and HttpOnly (not accessible to JavaScript). Expires when you sign out or after a reasonable inactivity period.</li>
+<li><strong>Verification cookie</strong> — short-lived; used only during the email-verification step at sign-up or sign-in.</li>
+</ul>
+<p>We do <strong>not</strong> use advertising cookies, tracking pixels, analytics cookies, or any third-party cookies.</p>
+<hr />
+<h2>How your data is stored and secured</h2>
+<ul>
+<li>All data is transmitted over HTTPS (TLS-encrypted in transit).</li>
+<li>Account data (email, passkey credentials, game history) is stored in <strong>MongoDB</strong> hosted by a managed MongoDB database host.</li>
+<li>Passkey credentials are stored as public-key material only; no passwords exist in our system.</li>
+<li>Session cookies are signed and HttpOnly to resist tampering and cross-site script access.</li>
+</ul>
+<p>We are a small hobby operation and implement reasonable security measures, but we cannot guarantee absolute security.</p>
+<hr />
+<h2>Third-party processors</h2>
+<p>We share data only with the vendors needed to operate the service. We do <strong>not</strong> sell your data.</p>
+<table>
+<thead>
+<tr>
+<th>Vendor</th>
+<th>Role</th>
+<th>Data involved</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Postmark</strong></td>
+<td>Transactional email (verification codes)</td>
+<td>Your email address</td>
+</tr>
+<tr>
+<td><strong>Heroku</strong></td>
+<td>Application hosting</td>
+<td>All app data in transit and at rest on Heroku infrastructure</td>
+</tr>
+<tr>
+<td><strong>Cloudflare</strong></td>
+<td>DNS and edge/CDN layer</td>
+<td>IP addresses and request metadata (standard CDN handling)</td>
+</tr>
+<tr>
+<td><strong>MongoDB host</strong></td>
+<td>Database storage</td>
+<td>Email, passkey credentials, game history</td>
+</tr>
+</tbody>
+</table>
+<p>Each vendor has its own privacy practices. We encourage you to review them if you have concerns.</p>
+<hr />
+<h2>Data retention and deletion</h2>
+<ul>
+<li>We retain your account data for as long as your account is active.</li>
+<li><strong>You can delete your account at any time</strong> using the "Delete account" button inside the app. This permanently and immediately removes your email address, passkey credentials, and all game history. Deletion is irreversible.</li>
+<li>We may retain anonymized, non-identifiable aggregate statistics (e.g., "N sessions were played this month") that cannot be linked back to you.</li>
+<li>If we receive a verifiable deletion request by email, we will process it within 30 days.</li>
+</ul>
+<hr />
+<h2>Children</h2>
+<p>This app is not directed to children under <strong>13</strong>. We do not knowingly collect personal data from anyone below that age. If you believe a child has created an account, contact us at privacy@moosequest.app and we will delete it promptly.</p>
+<hr />
+<h2>Your rights</h2>
+<p>Regardless of where you live, you can:</p>
+<ul>
+<li><strong>Access</strong> your data — contact us and we will tell you what we hold about you.</li>
+<li><strong>Delete</strong> your data — use the in-app "Delete account" button (instant) or contact privacy@moosequest.app.</li>
+<li><strong>Correct</strong> your data — contact us if your email address needs to change.</li>
+</ul>
+<p><strong>If you are in the European Union / European Economic Area / United Kingdom:</strong> You may have additional rights under the GDPR (or UK GDPR), including the right to object to processing, the right to data portability, and the right to lodge a complaint with your local supervisory authority. Our legal basis for processing your data is the performance of the service you signed up for (Art. 6(1)(b) GDPR) and, where required, your consent.</p>
+<p><strong>If you are in California:</strong> You may have rights under the CCPA/CPRA. We do not sell or share your personal information. We do not use it for cross-context behavioral advertising.</p>
+<hr />
+<h2>Changes to this policy</h2>
+<p>We may update this policy. If we make material changes, we will update the effective date at the top of this page. For a hobby app, we will make reasonable efforts to note significant changes; continued use after a change means you accept the updated policy.</p>
+<hr />
+<h2>Contact</h2>
+<p>Privacy questions or requests: <strong>privacy@moosequest.app</strong></p>
+<hr />
+</article>
+<p class="legal-foot"><a href="/privacy">Privacy</a> · <a href="/terms">Terms</a> · <a href="/">Home</a></p>
+</main>
+</body>
+</html>

--- a/web/styles.css
+++ b/web/styles.css
@@ -115,6 +115,8 @@ input[type=email]:focus, input[type=text]:focus { outline: none; border-color: v
 .btn.ghost { background: transparent; }
 .btn.big { padding: 15px 22px; font-size: 17px; width: 100%; margin-top: 8px; }
 .btn.tiny { padding: 6px 10px; font-size: 12px; }
+.btn.danger { color: var(--neg); border-color: rgba(255,93,115,0.4); }
+.btn.danger:hover { border-color: var(--neg); background: rgba(255,93,115,0.12); }
 .btn-row { display: flex; gap: 12px; flex-wrap: wrap; margin-top: 8px; }
 .btn-row .btn { flex: 1; min-width: 140px; }
 
@@ -213,6 +215,28 @@ input[type=email]:focus, input[type=text]:focus { outline: none; border-color: v
 .walk-dots { display: flex; gap: 8px; margin: 12px 0; }
 .walk-dots i { width: 8px; height: 8px; border-radius: 50%; background: var(--line); }
 .walk-dots i.on { background: var(--pink); box-shadow: var(--glow); }
+
+/* Site footer (legal links) */
+.site-foot { position: relative; z-index: 2; text-align: center; padding: 8px 18px 30px; color: var(--muted); font-size: 12px; }
+.site-foot a { color: var(--muted); }
+.site-foot a:hover { color: var(--cyan); }
+
+/* Legal pages (/privacy, /terms) */
+.legal { position: relative; z-index: 2; max-width: 760px; margin: 0 auto; padding: 26px 18px 80px; }
+.legal-back { display: inline-block; margin-bottom: 16px; color: var(--cyan); font-weight: 700; text-decoration: none; letter-spacing: 1px; }
+.legal-doc { background: var(--card); border: 1px solid var(--line); border-radius: var(--radius); padding: 28px 26px; box-shadow: 0 12px 40px rgba(0,0,0,0.45); }
+.legal-doc h1 { font-size: 28px; margin: 0 0 6px; background: linear-gradient(90deg, var(--cyan), var(--pink)); -webkit-background-clip: text; background-clip: text; color: transparent; }
+.legal-doc h2 { font-size: 18px; margin: 24px 0 8px; color: var(--ink); }
+.legal-doc p, .legal-doc li { color: var(--muted); line-height: 1.6; }
+.legal-doc strong { color: var(--ink); }
+.legal-doc a { color: var(--cyan); }
+.legal-doc hr { border: none; border-top: 1px solid var(--line); margin: 20px 0; }
+.legal-doc blockquote { border-left: 3px solid var(--pink); margin: 14px 0; padding: 8px 16px; background: rgba(255,78,205,0.08); border-radius: 8px; color: var(--ink); }
+.legal-doc table { width: 100%; border-collapse: collapse; margin: 12px 0; font-size: 14px; }
+.legal-doc th, .legal-doc td { border: 1px solid var(--line); padding: 8px 10px; text-align: left; vertical-align: top; color: var(--muted); }
+.legal-doc th { color: var(--ink); background: rgba(122,75,255,0.14); }
+.legal-foot { text-align: center; margin-top: 20px; color: var(--muted); font-size: 13px; }
+.legal-foot a { color: var(--cyan); }
 
 /* Mobile: tighten vertical rhythm so the dice + Roll button sit above the fold. */
 @media (max-width: 560px) {

--- a/web/terms.html
+++ b/web/terms.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Terms of Use · Dark Side Craps</title>
+<meta name="robots" content="all" />
+<link rel="stylesheet" href="/styles.css" />
+</head>
+<body>
+<div class="grid-bg" aria-hidden="true"></div>
+<main class="legal">
+<a class="legal-back" href="/">← Dark Side Craps</a>
+<article class="legal-doc">
+<h1>Terms of Use</h1>
+<p><strong>Effective date: July 16, 2026</strong></p>
+<p><em>This is a plain-language terms of use document for a small, free hobby app. It is not legal advice.</em></p>
+<hr />
+<h2>1. Who operates this app</h2>
+<p>Dark Side Craps (https://craps.moosequest.app) is operated by <strong>MooseQuest LLC</strong> ("we," "us," or "our"). By using this app you agree to these terms.</p>
+<hr />
+<h2>2. What this app is — and what it is not</h2>
+<p><strong>Dark Side Craps is a free, educational and entertainment-only strategy tracker.</strong> It generates simulated dice rolls and gives guidance on a "Don't Pass / lay-odds" craps strategy with a running scoreboard.</p>
+<p><strong>This is NOT gambling.</strong> There is no real money involved — no wagering, no deposits, no payouts, no prizes, no financial transactions of any kind. All bankroll figures, wins, and losses displayed are entirely fictional.</p>
+<p><strong>Nothing in this app is betting advice, financial advice, or gambling advice.</strong> The strategy described is one disciplined approach to a game of chance; it is not a guaranteed system and we make no claim that it will produce any particular result.</p>
+<hr />
+<h2>3. Eligibility</h2>
+<p>You must be at least <strong>18 years old</strong> (or the age of majority in your jurisdiction, if higher) to create an account and use this app. By using the app you represent that you meet this requirement.</p>
+<p>This app is not directed to anyone under the age of 13 and we do not knowingly collect data from minors. See our Privacy Policy for details.</p>
+<hr />
+<h2>4. Not for use in connection with real gambling</h2>
+<blockquote>
+<p><strong>Do not use this app at a casino, during real craps play, or to make real-money betting decisions.</strong></p>
+</blockquote>
+<p>This app exists for fun, self-education, and entertainment at home or wherever you enjoy strategy games. Simulated results under ideal conditions bear no necessary relationship to real-world craps outcomes. Real craps carries a house edge that no strategy can eliminate.</p>
+<hr />
+<h2>5. No warranties — "as is" and "as available"</h2>
+<p>THE APP IS PROVIDED <strong>"AS IS" AND "AS AVAILABLE"</strong> WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED. WE MAKE NO REPRESENTATIONS OR WARRANTIES REGARDING:</p>
+<ul>
+<li>Uptime, availability, or uninterrupted access;</li>
+<li>Accuracy of dice simulation, strategy guidance, or scoreboard calculations;</li>
+<li>Fitness for any particular purpose;</li>
+<li>Freedom from bugs, errors, or security vulnerabilities.</li>
+</ul>
+<p>We are a small hobby operation running a free app. We will try to keep it working, but we make no promises.</p>
+<hr />
+<h2>6. Limitation of liability</h2>
+<p>TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, <strong>MooseQuest LLC</strong> AND ITS MEMBERS, OFFICERS, AND AGENTS SHALL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR EXEMPLARY DAMAGES ARISING FROM YOUR USE OF (OR INABILITY TO USE) THIS APP, INCLUDING BUT NOT LIMITED TO:</p>
+<ul>
+<li>Any real-money gambling losses you incur, regardless of whether you used this app;</li>
+<li>Loss of data;</li>
+<li>Inaccuracies in strategy guidance or simulation results;</li>
+<li>Any reliance on this app for real-world decisions.</li>
+</ul>
+<p>Some jurisdictions do not allow certain liability exclusions; in those jurisdictions our liability is limited to the maximum extent permitted.</p>
+<hr />
+<h2>7. Acceptable use</h2>
+<p>You agree not to:</p>
+<ul>
+<li>Use the app for any unlawful purpose or in violation of any applicable law or regulation;</li>
+<li>Attempt to reverse-engineer, decompile, exploit, or attack the app, its infrastructure, or its data;</li>
+<li>Attempt to gain unauthorized access to other users' accounts or data;</li>
+<li>Use automated scraping, bots, or scripts against the service in a way that harms its operation;</li>
+<li>Impersonate another person or entity;</li>
+<li>Use the app in connection with real-money gambling or wagering.</li>
+</ul>
+<hr />
+<h2>8. Accounts and termination</h2>
+<p>You are responsible for maintaining the security of your account. We reserve the right to suspend or terminate any account at our discretion, including for violation of these terms or abuse of the service, without notice.</p>
+<p>You may delete your account at any time using the "Delete account" button in the app. Deletion is permanent and removes your email, passkey credentials, and game history.</p>
+<hr />
+<h2>9. Intellectual property</h2>
+<p>All content, design, code, and strategy guidance in this app is owned by <strong>MooseQuest LLC</strong> or its licensors. You may not reproduce, distribute, or create derivative works without our written permission.</p>
+<hr />
+<h2>10. Third-party services</h2>
+<p>The app relies on third-party infrastructure (hosting, email delivery, database, CDN). We are not responsible for the acts or omissions of those providers.</p>
+<hr />
+<h2>11. Changes to these terms</h2>
+<p>We may update these terms at any time. Changes take effect when we post the updated version with a new effective date. Continued use of the app after changes are posted constitutes acceptance of the updated terms. For significant changes we will make reasonable efforts to alert users.</p>
+<hr />
+<h2>12. Governing law and disputes</h2>
+<p>These terms are governed by the laws of <strong>the state in which MooseQuest LLC is organized</strong>, without regard to its conflict-of-law provisions.</p>
+<p>Any dispute arising from these terms or your use of the app shall be resolved in the state and federal courts located in that state. You waive any objection to jurisdiction or venue in those courts.</p>
+<hr />
+<h2>13. Contact</h2>
+<p>Questions about these terms: <strong>privacy@moosequest.app</strong></p>
+<hr />
+</article>
+<p class="legal-foot"><a href="/privacy">Privacy</a> · <a href="/terms">Terms</a> · <a href="/">Home</a></p>
+</main>
+</body>
+</html>


### PR DESCRIPTION
**Delete account** — authenticated `POST /auth/account/delete` permanently removes the user's email, passkey credentials, saved games, ceremonies, and verification codes, then clears the session. New "Delete account" button (with confirm) in the user menu. Verified E2E: every collection for the email drops to 0.

**Legal** — a Privacy Policy and Terms of Use (drafted by the legal-research agent; markdown under `docs/legal/`, rendered to styled, CSP-clean HTML at `/privacy` and `/terms`). Framing: entertainment-only / **not gambling** / "as is" no-warranty / don't use at a casino / 18+ / self-service deletion. Linked from a site footer ("For fun only — not gambling") and a consent line in the sign-in modal.

_Legal docs are plain-language drafts for a hobby app, not legal advice; entity/governing-law/contact set to sensible defaults (MooseQuest LLC, privacy@moosequest.app) to confirm._

🤖 Generated with [Claude Code](https://claude.com/claude-code)